### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/src/scripts.js
+++ b/src/scripts.js
@@ -81,6 +81,13 @@ document.addEventListener('DOMContentLoaded', function() {
   
             // Get the 'data-video-id' attribute value
             const videoId = videoWrapper.getAttribute('data-video-id');
+            
+            // Validate the video ID
+            const validVideoIdPattern = /^[a-zA-Z0-9_-]{11}$/;
+            if (!validVideoIdPattern.test(videoId)) {
+                console.error('Invalid video ID:', videoId);
+                return;
+            }
   
             // Get the video title from the h4 element
             const videoTitle = this.parentElement.querySelector('h4').textContent;


### PR DESCRIPTION
Potential fix for [https://github.com/mbianchidev/music-website/security/code-scanning/1](https://github.com/mbianchidev/music-website/security/code-scanning/1)

To fix the issue, we need to validate or sanitize the `videoId` variable before using it in the URL. A simple and effective approach is to use a regular expression to ensure that `videoId` contains only valid characters for a YouTube video ID (alphanumeric characters, dashes, and underscores). If the `videoId` does not match the expected pattern, we should either reject it or handle it safely (e.g., by not creating the iframe).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
